### PR TITLE
feat(auth): add GET /api/v1/me as single source of truth for session role

### DIFF
--- a/app/controllers/api/v1/me_controller.rb
+++ b/app/controllers/api/v1/me_controller.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    # Single-source-of-truth do estado de autenticação a partir do servidor.
+    #
+    # O front guardava `role`/`permissions` em localStorage e gateava UI por isso —
+    # qualquer adulteração local (`localStorage.setItem('role', 'admin')`) fazia
+    # a UI mostrar painel de DM (mutations continuavam sendo bloqueadas pelo
+    # backend, mas era confuso e dava falsa sensação de privilégio).
+    #
+    # Com este endpoint o front passa a derivar `role`/`permissions` direto da
+    # resposta autoritativa do servidor — não confia mais em localStorage para
+    # gates de UI. Veja `front-lafiga/src/app/context/UserContext.tsx`.
+    #
+    # `authorize_request` já recarrega `User` + `role` do DB a cada request,
+    # então não há cache nem possibilidade de claim adulterado: o JWT só
+    # carrega `user_id`.
+    class MeController < ApplicationController
+      include RoleSerializer
+
+      before_action :authorize_request
+
+      # GET /api/v1/me
+      # Retorna o mesmo schema do payload de login para o front reusar
+      # `mapUserInfosToAuthUser` sem ramificações. Diferença intencional vs.
+      # `AuthenticationController#login`: filtra `password_digest` da
+      # serialização. O login antigo vaza esse campo (bug pré-existente
+      # rastreado em follow-up); aqui não introduzimos a regressão.
+      def show
+        render json: {
+          user_infos: @current_user.as_json(except: SENSITIVE_USER_FIELDS),
+          role: serialize_role(@current_user.role.name),
+          permissions: @current_user.role.permissions
+        }, status: :ok
+      end
+
+      private
+
+      SENSITIVE_USER_FIELDS = %i[password_digest password_changed_at].freeze
+      private_constant :SENSITIVE_USER_FIELDS
+    end
+  end
+end

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -1,4 +1,6 @@
 class AuthenticationController < ApplicationController
+  include RoleSerializer
+
   before_action :authorize_request, except: [:login, :logout, :signup]
 
   def login
@@ -59,20 +61,5 @@ class AuthenticationController < ApplicationController
 
   def signup_params
     params.permit(:name, :username, :email, :password, :password_confirmation, :role_id)
-  end
-
-  # O front (UserContext) compara `user.role === 'dm'` em minúsculas. O banco
-  # guarda capitalizado ('DM', 'Player', 'Admin') porque o `Role.name` é a
-  # chave canônica do back (usada em policies). Aqui no payload de auth a
-  # gente normaliza pra lowercase pra bater com o contrato do front.
-  #
-  # `Admin` vira `dm` (alias legado: enquanto não migramos os usuários
-  # antigos, qualquer Admin é tratado como DM no front também).
-  def serialize_role(role_name)
-    return 'guest' if role_name.blank?
-    normalized = role_name.to_s.downcase
-    return 'dm' if normalized == 'admin'
-    return 'player' if normalized == 'user' # legado: 'User' role no seed antigo
-    normalized
   end
 end

--- a/app/controllers/concerns/role_serializer.rb
+++ b/app/controllers/concerns/role_serializer.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Normaliza o nome canónico do papel (Role.name no DB) para o contrato que o
+# front consome (`'dm' | 'player' | 'guest'`). O front compara em minúsculas
+# (`user.role === 'dm'`); o banco guarda capitalizado (`'DM'`, `'Player'`,
+# `'Admin'`) porque `Role.name` é a chave canônica usada em policies.
+#
+# - `Admin` é tratado como `dm` (alias legado: enquanto não migramos os
+#   usuários antigos, qualquer Admin é DM no front).
+# - `User` (papel legado do seed antigo) é tratado como `player`.
+#
+# Compartilhado entre `AuthenticationController` (login/signup) e
+# `Api::V1::MeController` (refresh do estado da sessão) para evitar
+# divergência de contrato entre as respostas de auth.
+module RoleSerializer
+  extend ActiveSupport::Concern
+
+  private
+
+  def serialize_role(role_name)
+    return 'guest' if role_name.blank?
+
+    normalized = role_name.to_s.downcase
+    return 'dm' if normalized == 'admin'
+    return 'player' if normalized == 'user' # legado: 'User' role no seed antigo
+
+    normalized
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,11 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
+      # Single source of truth do estado de autenticação a partir do servidor.
+      # Front consome após boot/login para derivar `role`/`permissions` em vez
+      # de confiar em localStorage. Ver `Api::V1::MeController`.
+      get 'me', to: 'me#show'
+
       namespace :admin do
         get 'dm_user_picker', to: 'dm_user_picker#index'
         resources :dm_users, only: %i[index show create update] do

--- a/spec/requests/api/v1/me_spec.rb
+++ b/spec/requests/api/v1/me_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::MeController', type: :request do
+  let(:player_role) { Role.find_by(name: 'Player') || create(:role, name: 'Player', permissions: []) }
+  let(:dm_role)     { Role.find_by(name: 'DM')     || create(:role, name: 'DM', permissions: %w[manage_sessions]) }
+  let(:admin_role)  { Role.find_by(name: 'Admin')  || create(:role, name: 'Admin', permissions: %w[manage_users manage_sessions]) }
+
+  let(:player) { create(:user, role: player_role) }
+  let(:dm)     { create(:user, role: dm_role) }
+  let(:admin)  { create(:user, role: admin_role) }
+
+  describe 'GET /api/v1/me' do
+    context 'sem token' do
+      it 'retorna 401' do
+        get '/api/v1/me'
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'com token JWT inválido' do
+      it 'retorna 401' do
+        get '/api/v1/me', headers: { 'Authorization' => 'Bearer not-a-real-token' }
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'Player autenticado' do
+      it 'retorna user_infos + role normalizado para "player" + permissions' do
+        get '/api/v1/me', headers: bearer_headers_for(player)
+
+        expect(response).to have_http_status(:ok)
+        body = response.parsed_body
+
+        expect(body['user_infos']['id']).to eq(player.id)
+        expect(body['user_infos']['email']).to eq(player.email)
+        expect(body['role']).to eq('player')
+        expect(body['permissions']).to eq([])
+      end
+
+      it 'NÃO inclui o password_digest no payload' do
+        get '/api/v1/me', headers: bearer_headers_for(player)
+        body = response.parsed_body
+        expect(body['user_infos'].keys).not_to include('password_digest', 'password')
+      end
+    end
+
+    context 'DM autenticado' do
+      it 'retorna role "dm" + permissions populadas' do
+        get '/api/v1/me', headers: bearer_headers_for(dm)
+
+        body = response.parsed_body
+        expect(body['role']).to eq('dm')
+        expect(body['permissions']).to include('manage_sessions')
+      end
+    end
+
+    context 'Admin autenticado' do
+      it 'retorna role "dm" (alias legado: Admin → dm no contrato do front)' do
+        get '/api/v1/me', headers: bearer_headers_for(admin)
+
+        body = response.parsed_body
+        expect(body['role']).to eq('dm')
+        expect(body['permissions']).to include('manage_users', 'manage_sessions')
+      end
+    end
+
+    context 'role mudou no DB depois de o token ser emitido' do
+      # Cenário do bug que motivou este endpoint: front confiava em
+      # `localStorage['role']` (cacheado do payload de login), então não
+      # detectava promoção/rebaixamento até o usuário re-logar. Aqui
+      # garantimos que /me sempre reflete o estado autoritativo do DB.
+      it 'reflete o role atual quando o usuário foi promovido a DM' do
+        headers = bearer_headers_for(player)
+        player.update!(role: dm_role)
+
+        get '/api/v1/me', headers: headers
+        expect(response.parsed_body['role']).to eq('dm')
+      end
+
+      it 'reflete o role atual quando o usuário foi rebaixado de DM para Player' do
+        headers = bearer_headers_for(dm)
+        dm.update!(role: player_role)
+
+        get '/api/v1/me', headers: headers
+        expect(response.parsed_body['role']).to eq('player')
+      end
+    end
+
+    context 'header com role/permissions falsificados pelo cliente' do
+      # Ataque que motivou o PR: usuário tenta sobrescrever role via
+      # `localStorage` (que vira parte de algumas requests headers ou body).
+      # O backend ignora qualquer pista de role enviada pelo cliente:
+      # JWT só carrega `user_id`, e o role é re-buscado do DB.
+      it 'ignora cabeçalho X-Role tentando promover Player a DM' do
+        get '/api/v1/me',
+            headers: bearer_headers_for(player).merge(
+              'X-Role' => 'dm',
+              'X-Permissions' => 'manage_users'
+            )
+
+        body = response.parsed_body
+        expect(body['role']).to eq('player')
+        expect(body['permissions']).to eq([])
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Sumário

PR A da iniciativa **role security hardening** (front + back).

Adiciona o endpoint `GET /api/v1/me` que vira a **fonte única de verdade** do estado de autenticação, devolvendo `{ user_infos, role, permissions }` autoritativos do servidor.

## Motivação

Um usuário descobriu privilege escalation **aparente** alterando \`localStorage['role']\` no front — passava a ver toolbar e rotas de DM. Em ambiente de produção, **mutations continuavam sendo bloqueadas** (JWT carrega só \`user_id\`; \`authorize_request\` re-busca \`User.role\` no DB a cada request), mas:

- o vazamento de UX era confuso (jogador "vê" botões de DM);
- defense-in-depth: front nunca deveria gateaer por valor lido do localStorage;
- algumas rotas DM podiam ainda fazer GETs públicos sem necessidade real, expondo dados.

Com o `/me` o front passa a derivar `role`/`permissions` da resposta autoritativa do servidor — não confia mais em localStorage para gates de UI.

## O que entra

### Controller + rota
- [app/controllers/api/v1/me_controller.rb](app/controllers/api/v1/me_controller.rb): `MeController#show` retorna o mesmo schema do payload de login para o front reusar `mapUserInfosToAuthUser` sem ramificar.
- [config/routes.rb](config/routes.rb): `GET /api/v1/me` no namespace v1.

### Concern (DRY)
- [app/controllers/concerns/role_serializer.rb](app/controllers/concerns/role_serializer.rb): \`serialize_role\` extraído de \`AuthenticationController\` e compartilhado com \`MeController\`. Garante contrato único entre login/signup/me — front recebe sempre \`'dm' | 'player' | 'guest'\`.

### Hardening intencional vs. login antigo
\`MeController\` filtra \`password_digest\` e \`password_changed_at\` da serialização. \`AuthenticationController#login/#signup\` ainda vazam \`password_digest\` (bug pré-existente — follow-up abaixo).

## Garantias de segurança

\`authorize_request\` já recarrega \`User\` + \`role\` do DB a cada request. JWT só carrega \`user_id\` (sem claims de role). Isso significa:

- ✅ Cliente não pode forjar role no JWT (sem claim).
- ✅ Cliente não pode enviar \`X-Role\`/\`X-Permissions\` e ser promovido — backend ignora (spec cobre).
- ✅ Promoção/rebaixamento no DB reflete imediatamente — sem cache (spec cobre).
- ✅ Token revogado (logout) é rejeitado pelo \`ValidateJwtToken\` whitelist.

## Specs

9 novos em [spec/requests/api/v1/me_spec.rb](spec/requests/api/v1/me_spec.rb), todos passando:

| Cenário | Esperado |
|---|---|
| Sem token | 401 |
| Token inválido | 401 |
| Player autenticado | \`role: 'player'\`, permissions \`[]\` |
| DM autenticado | \`role: 'dm'\`, permissions populadas |
| Admin autenticado | \`role: 'dm'\` (alias legado) |
| Payload **não** inclui \`password_digest\` | regressão guard |
| Role mudou no DB depois do token ser emitido | reflete na próxima chamada |
| Cliente envia \`X-Role: dm\` querendo promoção | ignorado |

## Como validar

\`\`\`bash
docker exec lafiga_api bundle exec rspec spec/requests/api/v1/me_spec.rb
# 9 examples, 0 failures

# Smoke manual (com token de player):
curl -H "Authorization: Bearer \$TOKEN" http://localhost:3001/api/v1/me
# => { "user_infos": {...sem password_digest}, "role": "player", "permissions": [] }
\`\`\`

## Stats

| Métrica | Antes | Depois |
|---|---|---|
| Suite total | 405 examples, 15 failures | **414 examples, 15 failures** (+9 novos, **0 novas falhas**) |
| Endpoints autoritativos para sessão | 0 | 1 |
| Vazamento de \`password_digest\` em \`/me\` | n/a | **filtrado** |

## Follow-ups (PRs separados)

- **PR B** (front): \`UserContext\`/\`AuthContext\` chamam \`/me\` no boot, removendo leituras de \`localStorage.getItem('role')\` para gates de UI.
- **PR C** (front): parar de gravar \`role\`/\`permissions\` no localStorage; manter só \`token\`.
- **PR D** (back): filtrar \`password_digest\` também em \`AuthenticationController#login\` e \`#signup\`.
- **PR E**: spec Rails de 403 cross-cutting + BDD test no front confirmando que tampering de localStorage não promove.

🤖 Generated with [Claude Code](https://claude.com/claude-code)