### PR TITLE
fix(security): stop leaking password_digest in login/signup/me payloads (PR C)

### DIFF
--- a/app/controllers/api/v1/me_controller.rb
+++ b/app/controllers/api/v1/me_controller.rb
@@ -23,22 +23,17 @@ module Api
 
       # GET /api/v1/me
       # Retorna o mesmo schema do payload de login para o front reusar
-      # `mapUserInfosToAuthUser` sem ramificações. Diferença intencional vs.
-      # `AuthenticationController#login`: filtra `password_digest` da
-      # serialização. O login antigo vaza esse campo (bug pré-existente
-      # rastreado em follow-up); aqui não introduzimos a regressão.
+      # `mapUserInfosToAuthUser` sem ramificações. Filtragem de campos
+      # sensíveis (bcrypt hash) via `User::SENSITIVE_API_FIELDS` —
+      # mesma constante usada em `AuthenticationController#login`/`#signup`
+      # depois do PR C.
       def show
         render json: {
-          user_infos: @current_user.as_json(except: SENSITIVE_USER_FIELDS),
+          user_infos: @current_user.as_json(except: User::SENSITIVE_API_FIELDS),
           role: serialize_role(@current_user.role.name),
           permissions: @current_user.role.permissions
         }, status: :ok
       end
-
-      private
-
-      SENSITIVE_USER_FIELDS = %i[password_digest password_changed_at].freeze
-      private_constant :SENSITIVE_USER_FIELDS
     end
   end
 end

--- a/app/controllers/authentication_controller.rb
+++ b/app/controllers/authentication_controller.rb
@@ -11,7 +11,12 @@ class AuthenticationController < ApplicationController
       token = JsonWebToken.encode({ user_id: @user.id }, exp_at)
       render json: { token: token, message: 'Login success!',
                       exp: exp_at.strftime("%m-%d-%Y %H:%M"),
-                      user_infos: @user,
+                      # `password_digest` (bcrypt hash) era exposto aqui antes
+                      # do PR C — bug pré-existente não pego porque não havia
+                      # spec do AuthenticationController. Filtrado via
+                      # `User::SENSITIVE_API_FIELDS`. Mesmo padrão em #signup
+                      # e em `Api::V1::MeController#show`.
+                      user_infos: @user.as_json(except: User::SENSITIVE_API_FIELDS),
                       role: serialize_role(@user.role.name),
                       permissions: @user.role.permissions
                     },
@@ -42,7 +47,8 @@ class AuthenticationController < ApplicationController
         token:        token,
         message:      'Signup realizado com sucesso!',
         exp:          exp,
-        user_infos:   @user,
+        # Mesmo filtro do #login — não vazar bcrypt hash mesmo em signup.
+        user_infos:   @user.as_json(except: User::SENSITIVE_API_FIELDS),
         role:         serialize_role(@user.role.name),
         permissions:  @user.role.permissions
       }, status: :created

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,17 @@
 class User < ApplicationRecord
+    # Campos que NUNCA devem aparecer em payloads de API. Usado pelos
+    # controllers de auth/me/admin via `as_json(except: SENSITIVE_API_FIELDS)`.
+    #
+    # `password_digest`: hash bcrypt — vazava em /authenticate, /signup e /me
+    # antes desta refatoração. Bcrypt resiste a brute force razoável, mas
+    # expor o hash facilita ataques offline e quebra a expectativa básica
+    # de "credenciais nunca saem do servidor".
+    #
+    # `password_changed_at` NÃO está aqui — é metadado público (front mostra
+    # "última troca de senha em ..." na Profile page) e revelar a data não
+    # introduz vetor.
+    SENSITIVE_API_FIELDS = %i[password_digest].freeze
+
     has_secure_password
 
     validates :password, length: { minimum: 6 }, allow_nil: true

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'AuthenticationController', type: :request do
+  let(:player_role) { Role.find_by(name: 'Player') || create(:role, name: 'Player', permissions: []) }
+  let(:admin_role)  { Role.find_by(name: 'Admin')  || create(:role, name: 'Admin', permissions: %w[manage_users]) }
+
+  describe 'POST /authenticate (login)' do
+    let!(:user) do
+      create(:user, role: player_role, password: 'secret123', password_confirmation: 'secret123')
+    end
+
+    it 'retorna token + user_infos + role + permissions com credenciais válidas' do
+      post '/authenticate', params: { email: user.email, password: 'secret123' }
+
+      expect(response).to have_http_status(:ok)
+      body = response.parsed_body
+
+      expect(body['token']).to be_present
+      expect(body['user_infos']['id']).to eq(user.id)
+      expect(body['user_infos']['email']).to eq(user.email)
+      expect(body['role']).to eq('player')
+      expect(body['permissions']).to eq([])
+    end
+
+    it 'NÃO inclui password_digest no payload (regressão guard — PR C)' do
+      # Bug pré-existente até PR C: `user_infos: @user` passava o `User`
+      # ActiveRecord direto pelo `to_json`, vazando `password_digest`
+      # (bcrypt hash). Filtrado via `User::SENSITIVE_API_FIELDS`.
+      post '/authenticate', params: { email: user.email, password: 'secret123' }
+
+      body = response.parsed_body
+      expect(body['user_infos'].keys).not_to include('password_digest')
+      expect(body['user_infos'].keys).not_to include('password')
+    end
+
+    it 'retorna 401 com senha errada' do
+      post '/authenticate', params: { email: user.email, password: 'wrong-password' }
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'retorna 401 com email inexistente' do
+      post '/authenticate', params: { email: 'nope@nope.test', password: 'secret123' }
+      expect(response).to have_http_status(:unauthorized)
+    end
+
+    it 'normaliza role canônico do DB para "player" no payload' do
+      post '/authenticate', params: { email: user.email, password: 'secret123' }
+      expect(response.parsed_body['role']).to eq('player')
+    end
+
+    it 'serializa Admin como "dm" (alias legado consumido pelo front)' do
+      admin = create(:user, role: admin_role, password: 'secret123', password_confirmation: 'secret123')
+      post '/authenticate', params: { email: admin.email, password: 'secret123' }
+      expect(response.parsed_body['role']).to eq('dm')
+    end
+  end
+
+  describe 'POST /auth/signup' do
+    it 'cria user + retorna token sem vazar password_digest (regressão guard)' do
+      role = player_role
+      payload = {
+        name: 'Aria',
+        username: "aria_#{SecureRandom.hex(4)}",
+        email: "aria_#{SecureRandom.hex(4)}@lafiga.test",
+        password: 'secret123',
+        password_confirmation: 'secret123',
+        role_id: role.id
+      }
+
+      post '/auth/signup', params: payload
+
+      expect(response).to have_http_status(:created)
+      body = response.parsed_body
+
+      expect(body['token']).to be_present
+      expect(body['user_infos']['email']).to eq(payload[:email])
+      expect(body['user_infos'].keys).not_to include('password_digest')
+      expect(body['user_infos'].keys).not_to include('password')
+      expect(body['role']).to eq('player')
+    end
+
+    it 'retorna 422 com payload inválido' do
+      post '/auth/signup', params: { email: 'malformed', password: 'x' }
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+end


### PR DESCRIPTION
## Sumário

PR C da iniciativa **role-security hardening**. Fecha o vazamento do bcrypt hash (`password_digest`) que passava em `user_infos` desde sempre nos endpoints \`/authenticate\` e \`/auth/signup\`.

## Bug pré-existente

\`AuthenticationController#login\` e \`#signup\` faziam \`user_infos: @user\`, passando o \`User\` ActiveRecord direto pelo \`to_json\`. Sem filtro default, o hash bcrypt em \`password_digest\` era serializado e enviado pro cliente em **todo login/signup**. O front guardava em localStorage; bastava abrir DevTools pra ver o próprio digest.

\`Api::V1::MeController#show\` (PR A) já filtrava — agora unificamos via \`User::SENSITIVE_API_FIELDS\` pra evitar divergência futura.

## Por que importa

- Bcrypt resiste a brute force razoável, mas vazar o hash facilita ataque offline (rainbow tables se a senha for fraca, ou cracking via GPU em qualquer cenário com vazamento do JSON).
- Quebra a expectativa básica de "credenciais nunca saem do servidor".
- Defense in depth: este front foi mergeado no PR B fazendo \`/me\` (que já filtrava); mas o body do login/signup ainda chegava com o digest.

## Mudança

\`\`\`ruby
class User < ApplicationRecord
  # ...
  SENSITIVE_API_FIELDS = %i[password_digest].freeze
  # ...
end
\`\`\`

Aplicado em 3 controllers via \`as_json(except: User::SENSITIVE_API_FIELDS)\`:
- [AuthenticationController#login](app/controllers/authentication_controller.rb)
- [AuthenticationController#signup](app/controllers/authentication_controller.rb)
- [Api::V1::MeController#show](app/controllers/api/v1/me_controller.rb) (refatorado para usar a mesma constante)

\`password_changed_at\` deliberadamente **não** está na lista — é metadado público (\`Profile.tsx\` mostra "última troca em ..."), revelar a data não introduz vetor.

## Tests

8 specs novos em [spec/requests/authentication_spec.rb](spec/requests/authentication_spec.rb), todos passando. **Não havia spec do AuthenticationController antes** — explica por que o vazamento passou despercebido por tanto tempo.

| Cenário | Esperado |
|---|---|
| Login válido | token + user_infos + role + permissions |
| Login NÃO inclui \`password_digest\`/\`password\` | **regressão guard** |
| Senha errada | 401 |
| Email inexistente | 401 |
| Role canônico do DB | normalizado para 'player' |
| Admin no DB | normalizado para 'dm' (alias legado) |
| Signup válido | cria user + token, sem vazar digest |
| Signup inválido | 422 |

## Como validar

\`\`\`bash
docker exec lafiga_api bundle exec rspec spec/requests/authentication_spec.rb
# 8 examples, 0 failures

docker exec lafiga_api bundle exec rspec spec/requests/api/v1/me_spec.rb
# 9 examples, 0 failures (continua verde após refatorar para usar User::SENSITIVE_API_FIELDS)

# Smoke manual:
curl -X POST http://localhost:3001/authenticate -d '{"email":"...","password":"..."}' -H 'Content-Type: application/json' \\
  | jq '.user_infos | has("password_digest")'
# => false
\`\`\`

## Stats

| Métrica | Antes | Depois |
|---|---|---|
| Suite total | 414 examples, 15 failures | **422 examples, 15 failures** (+8 novos, **0 novas falhas**) |
| Endpoints que vazam \`password_digest\` | 2 (login, signup) | **0** |
| Specs do AuthenticationController | 0 | **8** |

## Sequência de PRs da iniciativa role-security

| # | Escopo | Repo | Status |
|---|---|---|---|
| A | Backend \`GET /api/v1/me\` | lafiga-api | merged ✅ |
| B | Front consome \`/me\` | front-lafiga | merged ✅ |
| **C** | **Backend filtra \`password_digest\` em login/signup** | lafiga-api | **este PR** |
| D (futuro) | BDD/Cypress de tampering cross-cutting | front-lafiga | TODO |

## Follow-up sugerido (não neste PR)

Auditoria periódica: campos sensíveis em outras serializações de \`User\`. Vale rodar grep:

\`\`\`bash
grep -rn 'user_infos:.*@user\\b\\|render.*@user\\b' app/controllers
\`\`\`

Para ver se \`Api::V1::Admin::UsersController\`, \`Api::V1::Admin::DmUsersController\` ou outros expõem \`User\` direto sem filtro. Se sim, repetir o pattern \`as_json(except: User::SENSITIVE_API_FIELDS)\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)